### PR TITLE
Reset password forget url

### DIFF
--- a/loggedinonly.php
+++ b/loggedinonly.php
@@ -15,3 +15,12 @@ function logged_in_only() {
 	}
 }
 add_action( 'template_redirect', 'logged_in_only' );
+
+/*
+ * Reset the password reset url to wp default
+ */
+function logged_in_only_password_reset_url_reset() {
+	// Unset the password reset url filter from WooCommerce	
+	remove_filter( 'lostpassword_url', 'wc_lostpassword_url', 10 );
+}
+add_action( 'plugins_loaded', 'logged_in_only_password_reset_url_reset' );


### PR DESCRIPTION
Some plugins change the URL to the lost password interface.

WP-Default: https://www.example.com/wp-login.php?action=lostpassword
Woo-Default: https://www.example.com/my-account/lost-password/

If wp-logged-in-only and WooCommers are active a user can't reset the password without knowledge of the WP default URL. The Woo-Password-Reset-URL redirects the user to the frontend, but this is logged. wp-logged-in-only will then redirect the user back to the login form.
-> Loop

Therefore I propose this change so the password reset URL points to the default interface.

Maybe long term more filter need to be removed.
